### PR TITLE
Allow lowerValue and upperValue being equal

### DIFF
--- a/src/main/java/org/vaadin/addon/sliders/PaperRangeSlider.java
+++ b/src/main/java/org/vaadin/addon/sliders/PaperRangeSlider.java
@@ -65,8 +65,8 @@ public class PaperRangeSlider extends PolymerTemplate<PaperRangeSlider.RangeSlid
             throw new IllegalArgumentException("lowerValue must not be lower than min");
         }
 
-        if(lowerValue >= upperValue){
-            throw new IllegalArgumentException("lowerValue must not be larger or equal than upperValue");
+        if(lowerValue > upperValue){
+            throw new IllegalArgumentException("lowerValue must not be larger than upperValue");
         }
 
         final RangeSliderModel model = getModel();
@@ -218,8 +218,8 @@ public class PaperRangeSlider extends PolymerTemplate<PaperRangeSlider.RangeSlid
             }
 
 
-            if (lowerValue >= upperValue) {
-                throw new IllegalArgumentException("lower value (" + lowerValue + ") cannot be larger or equal upper value (" + upperValue + ")");
+            if (lowerValue > upperValue) {
+                throw new IllegalArgumentException("lower value (" + lowerValue + ") cannot be larger than upper value (" + upperValue + ")");
             }
 
             this.lowerValue = lowerValue;


### PR DESCRIPTION
It seems the underlying paper-slider actually allows the lowerValue and upperValue to be the same. At least I can drag the left knob all the way to the right one, which results in a 

 java.lang.IllegalArgumentException: lower value (6414) cannot be larger or equal upper value (6414)
	at org.vaadin.addon.sliders.PaperRangeSlider$IntRange.<init>(PaperRangeSlider.java:222) ~[paper-range-slider-1.1.3.jar:1.1.3]
	at org.vaadin.addon.sliders.PaperRangeSlider.getValue(PaperRangeSlider.java:84) ~[paper-range-slider-1.1.3.jar:1.1.3]
	at org.vaadin.addon.sliders.PaperRangeSlider.getValue(PaperRangeSlider.java:26) ~[paper-range-slider-1.1.3.jar:1.1.3]
	at com.vaadin.flow.component.AbstractField$ComponentValueChangeEvent.<init>(AbstractField.java:102) ~[flow-server-8.0.2.jar:8.0.2]
	at org.vaadin.addon.sliders.PaperRangeSlider.onValueChanged(PaperRangeSlider.java:148) ~[paper-range-slider-1.1.3.jar:1.1.3]
	[...]